### PR TITLE
tell sonar what branch it is on.

### DIFF
--- a/.azure/azureup.yaml
+++ b/.azure/azureup.yaml
@@ -27,10 +27,11 @@ stages:
               SONAR_LOGIN: $(sonarcloud.login)
           - script: |
               cd angular
-              npm run inspect
+              npm run inspect -- -Dsonar.branch.name=$BRANCH
             condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
             displayName: 'npm inspect::branch'
             env:
+              BRANCH: $(Build.SourceBranchName)
               SONAR_LOGIN: $(sonarcloud.login)
 
   - stage: 'pack'


### PR DESCRIPTION
Presently SonarCloud assumes every analysis is on branch `master`, leading to inconsistent reporting. This tells SonarCloud the current branch. `broker` has already been marked in SonarCloud as a "long-lived" branch like `master`.