### PR TITLE
fix pipeline scripts not failing before last line.

### DIFF
--- a/.azure/azureup.yaml
+++ b/.azure/azureup.yaml
@@ -12,11 +12,13 @@ stages:
           vmImage: 'ubuntu-16.04'
         steps:
           - script: |
+              set -e
               cd angular
               npm clean-install
               npm run test
             displayName: 'npm test'
           - script: |
+              set -e
               cd angular
               npm run inspect -- -Dsonar.pullrequest.base=master -Dsonar.pullrequest.branch=$PULL_REQUEST_BRANCH -Dsonar.pullrequest.github.repository=revaturexyz/housingxyz -Dsonar.pullrequest.key=$PULL_REQUEST_KEY -Dsonar.pullrequest.provider=GitHub
             condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
@@ -26,6 +28,7 @@ stages:
               PULL_REQUEST_KEY: $(System.PullRequest.PullRequestNumber)
               SONAR_LOGIN: $(sonarcloud.login)
           - script: |
+              set -e
               cd angular
               npm run inspect -- -Dsonar.branch.name=$BRANCH
             condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
@@ -66,6 +69,7 @@ stages:
               containerRegistry: 'revaturexyz-docker'
             displayName: 'docker login'
           - script: |
+              set -e
               cp $(ngenvdev.secureFilePath) angular/src/environments/environment.dev.ts
               docker image build --build-arg ANGULAR_CONFIGURATION=dev -f .docker/dockerfile -t housingxyz .
               docker image tag housingxyz revaturexyz/housingxyz:dev
@@ -73,6 +77,7 @@ stages:
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             displayName: 'docker push::dev'
           - script: |
+              set -e
               cp $(ngenvpre.secureFilePath) angular/src/environments/environment.pre.ts
               docker image build --build-arg ANGULAR_CONFIGURATION=pre -f .docker/dockerfile -t housingxyz .
               docker image tag housingxyz revaturexyz/housingxyz:pre
@@ -80,6 +85,7 @@ stages:
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/broker'))
             displayName: 'docker push::pre'
           - script: |
+              set -e
               cp $(ngenvstg.secureFilePath) angular/src/environments/environment.stg.ts
               docker image build --build-arg ANGULAR_CONFIGURATION=stg -f .docker/dockerfile -t housingxyz .
               docker image tag housingxyz revaturexyz/housingxyz:stg
@@ -124,6 +130,7 @@ stages:
               secureFile: 'terraform.housingxyz.pre.auto.tfvars'
             name: tfvars
           - script: |
+              set -e
               cp $(dkup.secureFilePath) .docker/
               cp $(tfkey.secureFilePath) $HOME/.terraformrc
               cp $(tfvars.secureFilePath) .terraformup/
@@ -173,6 +180,7 @@ stages:
               secureFile: 'terraform.housingxyz.dev.auto.tfvars'
             name: tfvars
           - script: |
+              set -e
               cp $(dkup.secureFilePath) .docker/
               cp $(tfkey.secureFilePath) $HOME/.terraformrc
               cp $(tfvars.secureFilePath) .terraformup/
@@ -222,6 +230,7 @@ stages:
               secureFile: 'terraform.housingxyz.stg.auto.tfvars'
             name: tfvars
           - script: |
+              set -e
               cp $(dkup.secureFilePath) .docker/
               cp $(tfkey.secureFilePath) $HOME/.terraformrc
               cp $(tfvars.secureFilePath) .terraformup/


### PR DESCRIPTION
by default, multiline `script` (and `bash`, etc.) steps in Azure Pipelines ignore errors except on the last command in the script.

for example, this step will ignore test failures:
```
- script: |
    dotnet test
    dotnet publish
```

this PR enables the `errexit` flag on all multiline scripts as a quick fix to restore more reasonable behavior.